### PR TITLE
Fix for tempvar2 in DESC_02_03DV.R

### DIFF
--- a/R/DESC_02_03DV.R
+++ b/R/DESC_02_03DV.R
@@ -218,14 +218,26 @@ DESC_02_03DV <- function(VCP = "DESC_02_03DV"){
                                                     1,tempvar2))
           } #end of j loop
 
-          dat <- dat %>%
-            mutate(
-              tempvar2 = ifelse((
-                (is.na(!!va) | !!va == "") &
-                  (str_to_upper(DESC_02_DENOMINATOR) == "RESPONDED") &
-                  psweight > 0 & !is.na(psweight)),
-                NA, tempvar2)
-            )
+          # Update 2026-04-23: implement same fix as in tempvar1
+          if ("character" %in% class(var)){
+            dat <- dat %>%
+              mutate(
+                tempvar2 = ifelse((
+                  (is.na(!!va) | !!va == "") &
+                    (str_to_upper(DESC_02_DENOMINATOR) == "RESPONDED") &
+                    psweight > 0 & !is.na(psweight)),
+                  NA, tempvar2)
+              )
+          } else {
+            dat <- dat %>%
+              mutate(
+                tempvar2 = ifelse((
+                  is.na(!!va) &
+                    str_to_upper(DESC_02_DENOMINATOR) == "RESPONDED" &
+                    psweight > 0 & !is.na(psweight)),
+                  NA, tempvar2)
+              )
+          }
 
           dat$tempvar2 <- haven::labelled(dat$tempvar2, label = sublabel) %>% suppressWarnings()
 


### PR DESCRIPTION
## Issue

When running the missvcqiR control program, I would come across the following error:

```
Error in `mutate()`:
ℹ In argument: `tempvar2 = ifelse(...)`.
Caused by error in `vec_equal()`:
! Can't combine `..1` <character> and `..2` <double>.
```

## Solution

This seems to happen because of the `!!va == ""` check for `tempvar2` in `DESC_02_03DV.R`. Given that a similar fix had been implemented for `tempvar1` in the same script, I implemented the same thing for `tempvar2` and then the program ran without issues.

Does this fix make sense? Could we merge it?

## Context

Specifically, this happens when calling the `DESC_02(cleanup = TRUE)` function in the following snippet of the control program:

```R
# ..............................................................................
# Study day table 1
vcqi_global(DESC_02_COVG_CRUDE_OR_VALID, "crude")
vcqi_global(DESC_02_DATASET, "MOV_dvs.rds")
vcqi_global(DESC_02_VARIABLES, paste0("table1_dv_", stringr::str_to_lower(DESC_02_COVG_CRUDE_OR_VALID)))
vcqi_global(DESC_02_WEIGHTED, "NO")
vcqi_global(DESC_02_DENOMINATOR, "ALL")

vcqi_global(DESC_02_LIST_N_BEFORE_PCT, "Yes")

# Proportion of Vaccinated, Unvaccinated and Undervaccinated
vcqi_global(DESC_02_TO_TITLE, language_string(language_use = language_use, str = "OS_113"))
# No subtitle or additional footnotes
vcqi_global(DESC_02_TO_SUBTITLE, NA)
# The proportion of children who had cards is the sum of those who were eligible for 1+ doses and those who were not
vcqi_global(DESC_02_TO_FOOTNOTE_4, language_string(language_use = language_use, str = "OS_114"))

vcqi_global(DESC_02_N_SUBTOTALS, 1)
vcqi_global(DESC_02_SUBTOTAL_LEVELS_1, c(0,1))
# Subtotal: Children who had cards
vcqi_global(DESC_02_SUBTOTAL_LABEL_1, language_string(language_use = language_use, str = "OS_115"))
vcqi_global(DESC_02_SUBTOTAL_LIST_1, "After 1")

# Total Interviews (N)
vcqi_global(DESC_02_N_LABEL,
            paste0(language_string(language_use = language_use, str = "OS_220"),
                   " ",
                   language_string(language_use = language_use, str = "OS_2")))

if (stringr::str_to_upper(DESC_02_COVG_CRUDE_OR_VALID) == "VALID"){
  # Note: Early doses are ignored in this analysis; the respondent is considered
  # to have not received them.
  vcqi_global(DESC_02_TO_FOOTNOTE_5, language_string(language_use = language_use, str = "OS_90"))
}

if (stringr::str_to_upper(DESC_02_COVG_CRUDE_OR_VALID) == "CRUDE"){
  # Note: Early doses are accepted in this analysis; all doses are considered
  # valid doses.
  vcqi_global(DESC_02_TO_FOOTNOTE_5, language_string(language_use = language_use, str = "OS_106"))
}

# Note: Number of children who had cards means they had card with valid dob and
# at least one dose date
vcqi_global(DESC_02_TO_FOOTNOTE_6, language_string(language_use = language_use, str = "OS_89"))

DESC_02(cleanup = TRUE)
```